### PR TITLE
feat(etl): record and merge self-play inputs into BattleData

### DIFF
--- a/src/elitefurretai/etl/ETL.md
+++ b/src/elitefurretai/etl/ETL.md
@@ -115,3 +115,13 @@ This workflow gathers and prepares competitive teams for the AI to use in self-p
 #### `team_repo.py` (`TeamRepo`)
 *   **Purpose**: Organized access to team files.
 *   **How it works**: Scans the `data/teams` directory. It can optionally spin up a local Showdown process to validate that the teams are legal for their format.
+
+#### `self_play.py` (`merge_input_logs`, `battle_order_to_input`, `build_self_play_battle_data`)
+*   **Purpose**: Serialize a *self-play* battle into a replayable `BattleData`. Showdown only writes a server-side `inputLog` for battles it hosts, so for our own agent-vs-agent games we reconstruct it from the orders each player made.
+*   **How it works**: `battle_order_to_input` / `teampreview_order_to_input` convert a poke-env order into the `">pX ..."` line format used by `BattleData.input_logs`. `merge_input_logs` interleaves the two players' separately-recorded inputs into one correctly-ordered list, driving the interleave off `BattleIterator`'s protocol walk so it stays correct across pivots, force switches, and revival blessing. `build_self_play_battle_data` ties it together with `BattleData.from_self_play`.
+*   **Design Choice**: Each player records only its own inputs (see `input_log_recorder.py`); the merge derives the interleaving from the protocol rather than guessing. Misalignment detection is best-effort — it raises on over-supply and on a mid-battle gap, but a missing *final* input is indistinguishable from the game's trailing decision and is not caught.
+
+#### `input_log_recorder.py` (`InputLogRecorder`)
+*   **Purpose**: Capture each order a player makes during self-play so it can be serialized — the "record" half of the self-play pipeline above.
+*   **How it works**: A mixin for a poke-env `Player` (e.g. `class Rec(InputLogRecorder, MaxDamagePlayer)`) that intercepts `choose_move`/`teampreview` and stores each order, keyed by `battle_tag`, in `">pX ..."` form. Works for both synchronous and async players.
+*   **Design Choice**: It lives in `etl/` rather than `agents/` because it is data-generation tooling for the self-play pipeline, not a battle agent you instantiate to play.

--- a/src/elitefurretai/etl/__init__.py
+++ b/src/elitefurretai/etl/__init__.py
@@ -13,6 +13,10 @@ Feature Engineering:
     - embedder: Convert game state to neural network features
     - encoder: MDBO action space encoding/decoding
 
+Self-Play Serialization:
+    - self_play: Reconstruct/merge self-play orders into a replayable BattleData
+    - input_log_recorder: Player mixin that records each order as it is made
+
 Validation & Utilities:
     - battle_order_validator: Validate BattleOrders are legal
     - evaluate_state: Heuristic position evaluation
@@ -42,6 +46,15 @@ from elitefurretai.etl.compress_utils import load_compressed, save_compressed
 from elitefurretai.etl.embedder import Embedder
 from elitefurretai.etl.encoder import MDBO, MoveOrderEncoder
 from elitefurretai.etl.evaluate_state import evaluate_position_advantage
+
+# Self-play serialization
+from elitefurretai.etl.input_log_recorder import InputLogRecorder
+from elitefurretai.etl.self_play import (
+    battle_order_to_input,
+    build_self_play_battle_data,
+    merge_input_logs,
+    teampreview_order_to_input,
+)
 from elitefurretai.etl.team_repo import TeamRepo
 
 __all__ = [
@@ -61,4 +74,10 @@ __all__ = [
     "TeamRepo",
     "load_compressed",
     "save_compressed",
+    # Self-play serialization
+    "InputLogRecorder",
+    "battle_order_to_input",
+    "teampreview_order_to_input",
+    "merge_input_logs",
+    "build_self_play_battle_data",
 ]

--- a/src/elitefurretai/etl/battle_iterator.py
+++ b/src/elitefurretai/etl/battle_iterator.py
@@ -25,6 +25,7 @@ class BattleIterator:
         self._perspective = perspective
         self._omniscient = omniscient
         self._last_input_type: Optional[str] = None
+        self._last_input_owners: List[str] = []
 
     def __str__(self):
         return f"""
@@ -98,9 +99,12 @@ class BattleIterator:
         if self._is_pivot_trigger():
             self._input_nums = [self._input_nums[1], self._input_nums[1] + 1]
             self._last_input_type = MDBO.FORCE_SWITCH
+            # Owner is the actor of the pivot-triggering log line
+            self._last_input_owners = [self.log.split("|")[2][:2]]
         elif self._is_teampreview():
             self._input_nums = [self._input_nums[1], self._input_nums[1] + 2]
             self._last_input_type = MDBO.TEAMPREVIEW
+            self._last_input_owners = ["p1", "p2"]
 
             # if omniscient, populate opponent teampreview
             if self._omniscient:
@@ -123,16 +127,22 @@ class BattleIterator:
             self._input_nums = [self._input_nums[1], self._input_nums[1] + 2]
             self._prev_turn_index = self._index
             self._last_input_type = MDBO.TURN
+            self._last_input_owners = ["p1", "p2"]
         elif self._is_revival_blessing():
             self._input_nums = [self._input_nums[1], self._input_nums[1] + 1]
             self._last_input_type = MDBO.FORCE_SWITCH
+            # Owner is the actor of the Revival Blessing log line
+            self._last_input_owners = [self.log.split("|")[2][:2]]
         # Can either be two or one, depending on who faints; we deduce whether we need
         # two or one by the order of the player inputs in the player log
         elif self._is_preturn_switch():
-            if self._need_switch("p1") and self._need_switch("p2"):
+            need_p1, need_p2 = self._need_switch("p1"), self._need_switch("p2")
+            if need_p1 and need_p2:
                 self._input_nums = [self._input_nums[1], self._input_nums[1] + 2]
+                self._last_input_owners = ["p1", "p2"]
             else:
                 self._input_nums = [self._input_nums[1], self._input_nums[1] + 1]
+                self._last_input_owners = ["p1"] if need_p1 else ["p2"]
             self._last_input_type = MDBO.FORCE_SWITCH
 
         # If I hit a new request for my perspective, I should simulate the request to fill in the
@@ -233,6 +243,16 @@ class BattleIterator:
     @property
     def last_input_type(self) -> Optional[str]:
         return self._last_input_type
+
+    @property
+    def last_input_owners(self) -> List[str]:
+        """Owners (p1/p2) of the inputs in the current input_nums slice, in slot order."""
+        return self._last_input_owners
+
+    @property
+    def input_nums(self) -> List[int]:
+        """[start, end) slice into bd.input_logs for the current decision."""
+        return self._input_nums
 
     @property
     def last_opponent_input(self) -> Optional[str]:

--- a/src/elitefurretai/etl/input_log_recorder.py
+++ b/src/elitefurretai/etl/input_log_recorder.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""input_log_recorder.py
+
+``InputLogRecorder`` — a mixin for poke-env ``Player`` subclasses that records every
+order the player makes, in decision order, keyed by ``battle_tag``, in the
+``BattleData.input_logs`` (`">pX ..."`) format.
+
+Self-play battles have no server-side ``inputLog``, so to serialize them into a
+replayable ``BattleData`` we must capture each player's own inputs as they are made.
+Mix this into the players used for self-play data generation, then combine the two
+players' recorded logs with ``etl.build_self_play_battle_data`` (or ``merge_input_logs``)::
+
+    class RecordingMaxDamage(InputLogRecorder, MaxDamagePlayer):
+        pass
+
+    p1, p2 = RecordingMaxDamage(...), RecordingMaxDamage(...)
+    await p1.battle_against(p2, n_battles=1)
+    bd = build_self_play_battle_data(
+        p1_battle, p2_battle, p1.get_input_log(tag), p2.get_input_log(tag)
+    )
+
+Works with both synchronous and ``async`` ``choose_move`` / ``teampreview`` players;
+ordering is preserved because poke-env requests (and therefore our overrides) fire
+once per decision, in order.
+"""
+
+import inspect
+from typing import Any, Awaitable, Dict, List, Union
+
+from poke_env.battle import AbstractBattle
+
+from elitefurretai.etl.self_play import (
+    battle_order_to_input,
+    teampreview_order_to_input,
+)
+
+
+class InputLogRecorder:
+    """Mixin that records a player's orders into ``BattleData.input_logs`` format.
+
+    Place it BEFORE the concrete ``Player`` in the MRO so ``super()`` resolves to the
+    real agent (e.g. ``class Rec(InputLogRecorder, MaxDamagePlayer)``).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        # battle_tag -> ordered list of ">pX ..." input lines
+        self._recorded_input_logs: Dict[str, List[str]] = {}
+
+    def get_input_log(self, battle_tag: str) -> List[str]:
+        """The recorded inputs for a battle, in the order they were made."""
+        return self._recorded_input_logs.get(battle_tag, [])
+
+    def clear_input_logs(self) -> None:
+        self._recorded_input_logs.clear()
+
+    def _record(self, battle: AbstractBattle, line: Union[str, None]) -> None:
+        if line is not None:
+            self._recorded_input_logs.setdefault(battle.battle_tag, []).append(line)
+
+    def choose_move(self, battle: AbstractBattle) -> Any:
+        result = super().choose_move(battle)  # type: ignore[misc]
+        if inspect.isawaitable(result):
+
+            async def _await_and_record() -> Any:
+                order = await result
+                self._record(battle, battle_order_to_input(order, battle))
+                return order
+
+            return _await_and_record()
+        self._record(battle, battle_order_to_input(result, battle))
+        return result
+
+    def teampreview(self, battle: AbstractBattle) -> Union[str, Awaitable[str]]:
+        result = super().teampreview(battle)  # type: ignore[misc]
+        role = battle.player_role
+        assert role is not None
+        if inspect.isawaitable(result):
+
+            async def _await_and_record() -> str:
+                order = await result
+                self._record(battle, teampreview_order_to_input(order, role))
+                return order
+
+            return _await_and_record()
+        self._record(battle, teampreview_order_to_input(result, role))
+        return result

--- a/src/elitefurretai/etl/self_play.py
+++ b/src/elitefurretai/etl/self_play.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""self_play.py
+
+Helpers to serialize a *self-play* battle into a replayable ``BattleData``.
+
+Showdown only writes a server-side ``inputLog`` for battles it hosts; when we run
+our own agents against each other we instead have to reconstruct that input log
+from the orders the agents made. This module provides:
+
+* ``battle_order_to_input`` / ``teampreview_order_to_input`` — convert a poke-env
+  order made on a battle into the ``">pX ..."`` line format used by
+  ``BattleData.input_logs`` (and parsed back by ``BattleIterator.last_order``).
+* ``merge_input_logs`` — interleave each player's own ordered inputs into the
+  single, correctly-ordered ``input_logs`` that ``BattleIterator`` expects. The
+  interleaving (which player acts, and in what order, at each decision — including
+  one- or two-sided force switches) is driven by the protocol via ``BattleIterator``
+  rather than guessed, so it stays correct across pivots, faints and revival blessing.
+* ``build_self_play_battle_data`` — glue: build a ``BattleData`` from two finished
+  battles plus each player's recorded inputs (see ``input_log_recorder.InputLogRecorder``).
+"""
+
+from collections import deque
+from typing import List, Optional
+
+from poke_env.battle import AbstractBattle, Move, Pokemon
+from poke_env.player.battle_order import (
+    BattleOrder,
+    DefaultBattleOrder,
+    DoubleBattleOrder,
+    ForfeitBattleOrder,
+    SingleBattleOrder,
+)
+
+from elitefurretai.etl.battle_data import BattleData
+from elitefurretai.etl.battle_iterator import BattleIterator
+
+
+def _switch_slot(mon: Pokemon, battle: AbstractBattle, role: str) -> int:
+    """Showdown switch orders reference the 1-indexed position of the target in the
+    request's ``side.pokemon`` list -- which is what ``BattleIterator``/``MDBO`` decode
+    against. We resolve the slot from the live request and do NOT fall back to
+    ``battle.team`` dict order: per ``encoder.py`` that order is not guaranteed to match
+    the request, so guessing could emit a wrong (silently mislabeled) switch."""
+    target = mon.identifier(role)
+    request = battle.last_request or {}
+    side_pokemon = request.get("side", {}).get("pokemon", []) if request else []
+    for i, entry in enumerate(side_pokemon):
+        if entry.get("ident") == target:
+            return i + 1
+    raise ValueError(
+        f"Could not resolve switch slot for {target} in {battle.battle_tag}: not found "
+        f"in request side.pokemon ({len(side_pokemon)} entries). A live request is "
+        "required to serialize a switch order."
+    )
+
+
+def _single_order_to_str(
+    order: SingleBattleOrder, battle: AbstractBattle, role: str
+) -> str:
+    o = order.order
+    # Pass/default are stored as raw strings on the SingleBattleOrder (e.g. "/choose pass").
+    if isinstance(o, str):
+        return o.replace("/choose ", "")
+    if isinstance(o, Move):
+        part = f"move {o.id}"
+        # Foe targets are written "+1"/"+2", ally targets "-1"/"-2", self/spread omit it.
+        if order.move_target != 0:
+            part += (
+                f" +{order.move_target}"
+                if order.move_target > 0
+                else f" {order.move_target}"
+            )
+        # Gimmick token comes last (matches the MDBO mapping + BattleIterator.last_order).
+        if order.terastallize:
+            part += " terastallize"
+        elif order.mega:
+            part += " mega"
+        elif order.dynamax:
+            part += " dynamax"
+        elif order.z_move:
+            part += " zmove"
+        return part
+    if isinstance(o, Pokemon):
+        return f"switch {_switch_slot(o, battle, role)}"
+    raise ValueError(f"Unrecognized single order {order!r} in {battle.battle_tag}")
+
+
+def battle_order_to_input(order: BattleOrder, battle: AbstractBattle) -> Optional[str]:
+    """Convert an order made on ``battle`` into a ``">pX ..."`` input-log line.
+
+    Returns ``None`` for orders we don't serialize (default / forfeit), so callers
+    can simply skip them.
+    """
+    role = battle.player_role
+    assert role is not None, "battle.player_role must be set to serialize an order"
+    if isinstance(order, (DefaultBattleOrder, ForfeitBattleOrder)):
+        return None
+    if isinstance(order, DoubleBattleOrder):
+        first = _single_order_to_str(order.first_order, battle, role)
+        second = _single_order_to_str(order.second_order, battle, role)
+        return f">{role} {first}, {second}"
+    if isinstance(order, SingleBattleOrder):
+        return f">{role} {_single_order_to_str(order, battle, role)}"
+    return None
+
+
+def teampreview_order_to_input(order: str, role: str) -> str:
+    """Convert a poke-env teampreview string ("/team 4513" or "/team 4, 5, 1, 3")
+    into the ``">pX team a, b, c, d"`` form used by ``BattleData.input_logs``."""
+    digits = [c for c in order if c.isdigit()]
+    return f">{role} team " + ", ".join(digits)
+
+
+def merge_input_logs(
+    bd: BattleData, p1_input_log: List[str], p2_input_log: List[str]
+) -> List[str]:
+    """Interleave each player's own ordered inputs into ``bd.input_logs``.
+
+    ``bd`` must already have ``logs`` and teams populated (e.g. from
+    ``BattleData.from_self_play``); ``bd.input_logs`` is rebuilt in place and also
+    returned. ``p1_input_log`` / ``p2_input_log`` are each player's ``">pX ..."``
+    inputs in the order that player made them (teampreview first).
+
+    Misalignment detection is best-effort, not a guarantee. We raise on over-supply
+    (inputs left unconsumed) and on a mid-battle gap (a decision with no recorded
+    input that is followed by a later one). We CANNOT detect a missing *final* input:
+    an empty queue on the last decision is indistinguishable from the legitimate
+    trailing decision the game ends on. Callers must record one input per decision
+    (see ``InputLogRecorder``); these guards catch many mistakes, but not that one.
+    """
+    queues = {"p1": deque(p1_input_log), "p2": deque(p2_input_log)}
+    bd.input_logs = []  # grown just-in-time as the iterator walks the protocol
+
+    it = BattleIterator(bd, perspective="p1", omniscient=True)
+    last_nums = list(it.input_nums)
+    # An empty owner queue at a decision means no input was recorded for it. That is
+    # only legitimate for the trailing decision the game ends on -- a force switch (a
+    # faint with the win already decided) or even a bare "|turn|N" emitted just before
+    # "|win|". So a skip is fine ONLY if nothing is placed afterwards; if we skip and
+    # then place a later input, the stream is under-supplied / misaligned (e.g. a
+    # default/timeout order that was never recorded -- poke-env can send
+    # `choose_default_move` without ever calling `choose_move`). Fail loudly then.
+    underflowed = False
+    guard = 0
+    while not it.battle.finished and guard < 1_000_000:
+        guard += 1
+        try:
+            it.next()
+        except StopIteration:
+            break
+        # A new decision was classified when the input slice advances to a non-empty range.
+        if it.input_nums != last_nums and it.input_nums[1] > it.input_nums[0]:
+            last_nums = list(it.input_nums)
+            for owner in it.last_input_owners:
+                if queues[owner]:
+                    if underflowed:
+                        raise ValueError(
+                            f"merge_input_logs: a decision in {bd.battle_tag} had no recorded "
+                            "input but a later one was placed -- the input streams are "
+                            "under-supplied or misaligned (e.g. an unrecorded default order)."
+                        )
+                    bd.input_logs.append(queues[owner].popleft())
+                else:
+                    underflowed = True
+
+    # And both streams must be fully consumed; leftover inputs mean the opposite
+    # (over-supply): more was recorded than the protocol asked for.
+    leftover = {role: list(q) for role, q in queues.items() if q}
+    if leftover:
+        raise ValueError(
+            f"merge_input_logs left inputs unconsumed for {bd.battle_tag}: {leftover}. "
+            f"Merged {len(bd.input_logs)} of {len(p1_input_log) + len(p2_input_log)} inputs."
+        )
+    return bd.input_logs
+
+
+def build_self_play_battle_data(
+    p1_battle: AbstractBattle,
+    p2_battle: AbstractBattle,
+    p1_input_log: List[str],
+    p2_input_log: List[str],
+) -> BattleData:
+    """Build a replayable ``BattleData`` from two finished self-play battles and each
+    player's recorded inputs (e.g. from two ``InputLogRecorder`` players)."""
+    bd = BattleData.from_self_play(p1_battle, p2_battle, input_logs=[])
+    merge_input_logs(bd, p1_input_log, p2_input_log)
+    return bd

--- a/unit_tests/etl/test_input_log_recorder.py
+++ b/unit_tests/etl/test_input_log_recorder.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+
+from poke_env.battle import AbstractBattle, Move
+from poke_env.player.battle_order import (
+    DoubleBattleOrder,
+    PassBattleOrder,
+    SingleBattleOrder,
+)
+
+from elitefurretai.etl.input_log_recorder import InputLogRecorder
+
+
+def _battle(role="p1", tag="battle-1") -> AbstractBattle:
+    # The recorder + move/pass conversion only read player_role and battle_tag.
+    return cast(AbstractBattle, SimpleNamespace(player_role=role, battle_tag=tag))
+
+
+def _dbo(move_id, target, second=None):
+    first = SingleBattleOrder(order=Move(move_id, gen=9), move_target=target)
+    return DoubleBattleOrder(first, second if second is not None else PassBattleOrder())
+
+
+class _SyncStub:
+    def __init__(self, orders, tp="/team 1, 2, 3, 4"):
+        self._orders = list(orders)
+        self._i = 0
+        self._tp = tp
+
+    def choose_move(self, battle):
+        order = self._orders[self._i]
+        self._i += 1
+        return order
+
+    def teampreview(self, battle):
+        return self._tp
+
+
+class _AsyncStub(_SyncStub):
+    async def choose_move(self, battle):
+        return super().choose_move(battle)
+
+    async def teampreview(self, battle):
+        return super().teampreview(battle)
+
+
+class _SyncRecorder(InputLogRecorder, _SyncStub):
+    pass
+
+
+class _AsyncRecorder(InputLogRecorder, _AsyncStub):
+    pass
+
+
+def test_records_teampreview_and_orders_in_decision_order():
+    player = _SyncRecorder(
+        [
+            _dbo("uturn", 2, SingleBattleOrder(order=Move("protect", gen=9))),
+            _dbo("fakeout", 1),
+        ],
+        tp="/team 4, 5, 1, 3",
+    )
+    battle = _battle(role="p1", tag="t1")
+
+    player.teampreview(battle)
+    player.choose_move(battle)
+    player.choose_move(battle)
+
+    assert player.get_input_log("t1") == [
+        ">p1 team 4, 5, 1, 3",
+        ">p1 move uturn +2, move protect",
+        ">p1 move fakeout +1, pass",  # second slot defaults to a pass
+    ]
+
+
+def test_separates_logs_by_battle_tag_and_role():
+    player = _SyncRecorder([_dbo("surf", 0)], tp="/team 1, 2, 3, 4")
+    player.teampreview(_battle(role="p2", tag="A"))
+    player.choose_move(_battle(role="p2", tag="A"))
+    assert player.get_input_log("A") == [">p2 team 1, 2, 3, 4", ">p2 move surf, pass"]
+    assert player.get_input_log("missing") == []
+
+
+def test_works_with_async_players():
+    player = _AsyncRecorder([_dbo("spore", 1)], tp="/team 2, 4, 1, 6")
+    battle = _battle(role="p1", tag="async-1")
+
+    # teampreview's declared return is Union[str, Awaitable[str]]; the async stub
+    # yields a coroutine here, which asyncio.run accepts.
+    asyncio.run(player.teampreview(battle))  # type: ignore[arg-type]
+    asyncio.run(player.choose_move(battle))
+
+    assert player.get_input_log("async-1") == [
+        ">p1 team 2, 4, 1, 6",
+        ">p1 move spore +1, pass",
+    ]

--- a/unit_tests/etl/test_self_play.py
+++ b/unit_tests/etl/test_self_play.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+import glob
+import os
+from types import SimpleNamespace
+
+import orjson
+import pytest
+from poke_env.battle import Observation
+from poke_env.player.battle_order import DefaultBattleOrder, ForfeitBattleOrder
+
+from elitefurretai.etl import BattleData, BattleIterator
+from elitefurretai.etl.encoder import MDBO
+from elitefurretai.etl.self_play import (
+    battle_order_to_input,
+    build_self_play_battle_data,
+    merge_input_logs,
+    teampreview_order_to_input,
+)
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))),
+    "data/fixture/gen9vgc2023regc_logs",
+)
+FILES = sorted(glob.glob(os.path.join(FIXTURE_DIR, "*.json")))
+IDS = [os.path.basename(f) for f in FILES]
+
+
+def _load(path):
+    with open(path, "rb") as f:
+        return BattleData.from_showdown_json(orjson.loads(f.read()))
+
+
+def _split(input_logs):
+    return (
+        [s for s in input_logs if s.startswith(">p1")],
+        [s for s in input_logs if s.startswith(">p2")],
+    )
+
+
+def _perspective_inputs(bd, perspective):
+    it = BattleIterator(bd, perspective=perspective)
+    seq = []
+    while True:
+        try:
+            if it.next_input() is None:
+                break
+        except StopIteration:
+            break
+        seq.append(it.last_input)
+    return seq
+
+
+def test_teampreview_order_to_input_formats():
+    # poke-env may hand either a packed or comma-separated /team order
+    assert teampreview_order_to_input("/team 4513", "p1") == ">p1 team 4, 5, 1, 3"
+    assert teampreview_order_to_input("/team 4, 5, 1, 3", "p2") == ">p2 team 4, 5, 1, 3"
+
+
+def test_battle_order_to_input_skips_default_and_forfeit():
+    battle = SimpleNamespace(player_role="p1", battle_tag="t")
+    assert battle_order_to_input(DefaultBattleOrder(), battle) is None  # type: ignore[arg-type]
+    assert battle_order_to_input(ForfeitBattleOrder(), battle) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_last_input_owners_match_input_prefixes(path):
+    """The iterator's `last_input_owners` matches the actual ">pX" owners of the
+    inputs in its slice, for every real decision (the trailing phantom force switch
+    at game end has an out-of-range slice and is skipped)."""
+    bd = _load(path)
+    it = BattleIterator(bd, perspective="p1", omniscient=True)
+    last = list(it.input_nums)
+    while not it.battle.finished:
+        try:
+            it.next()
+        except StopIteration:
+            break
+        if it.input_nums != last and it.input_nums[1] > it.input_nums[0]:
+            last = list(it.input_nums)
+            start, end = it.input_nums
+            if end <= len(bd.input_logs):  # skip the trailing no-input force switch
+                expected = [bd.input_logs[i][1:3] for i in range(start, end)]
+                assert it.last_input_owners == expected
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_merge_input_logs_raises_on_over_supply(path):
+    """Surplus recorded inputs that never get placed must fail loudly rather than
+    silently misalign the merged log. (Several extras, since a trailing phantom
+    decision can legitimately absorb at most one or two.)"""
+    bd = _load(path)
+    p1_log, p2_log = _split(bd.input_logs)
+    surplus = [">p1 move tackle +1, pass"] * 3
+    with pytest.raises(ValueError):
+        merge_input_logs(bd, p1_log + surplus, p2_log)
+
+
+def test_merge_input_logs_raises_on_mid_battle_under_supply():
+    """A missing input that is followed by later inputs is caught (here, a dropped p1
+    move mid-battle). NOTE: a missing *final* input is NOT detectable -- it is
+    indistinguishable from the game's trailing decision; see merge_input_logs."""
+    bd = _load(os.path.join(FIXTURE_DIR, "gen9vgc2023regc_anon10.json"))
+    p1_log, p2_log = _split(bd.input_logs)
+    under = p1_log[:1] + p1_log[2:]  # drop p1's first move, keep teampreview
+    with pytest.raises(ValueError):
+        merge_input_logs(bd, under, p2_log)
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_merge_input_logs_round_trips(path):
+    """Splitting an input log per-player and merging it back reproduces it exactly,
+    fully draining both players' streams (the protocol-driven interleaving is correct
+    across pivots, one/two-sided force switches and revival blessing)."""
+    bd = _load(path)
+    original = list(bd.input_logs)
+    p1_log, p2_log = _split(original)
+
+    merged = merge_input_logs(bd, p1_log, p2_log)
+
+    assert merged == original
+    assert bd.input_logs == original
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_merged_input_logs_replay_with_iterator(path):
+    """A BattleData rebuilt via merge_input_logs replays identically for both players."""
+    bd = _load(path)
+    expected = {p: _perspective_inputs(bd, p) for p in ("p1", "p2")}
+
+    p1_log, p2_log = _split(bd.input_logs)
+    merge_input_logs(bd, p1_log, p2_log)
+
+    for perspective in ("p1", "p2"):
+        assert _perspective_inputs(bd, perspective) == expected[perspective]
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_battle_order_to_input_round_trips(path):
+    """Every real (non-struggle) decision converts back to its original input line:
+    last_input -> last_order -> DoubleBattleOrder -> battle_order_to_input."""
+    bd = _load(path)
+    checked = 0
+    for perspective in ("p1", "p2"):
+        it = BattleIterator(bd, perspective=perspective)
+        while True:
+            try:
+                if it.next_input() is None:
+                    break
+            except StopIteration:
+                break
+            expected = it.last_input
+            if expected is None:
+                continue
+            # struggle/recharge are not in the moveset; they collapse to slot 1 through
+            # MDBO and are masked by the training pipeline, so skip them here.
+            if "struggle" in expected or "recharge" in expected:
+                continue
+
+            if it.last_input_type == MDBO.TEAMPREVIEW:
+                raw = "/team " + expected.split(" team ")[1]
+                assert teampreview_order_to_input(raw, perspective) == expected
+            else:
+                dbo = it.last_order().to_double_battle_order(it.battle)  # type: ignore[arg-type]
+                assert battle_order_to_input(dbo, it.battle) == expected
+            checked += 1
+    assert checked > 0
+
+
+def _faithful_self_play_battle(bd, perspective):
+    """A finished DoubleBattle with real teams (reconstructed via the iterator) and
+    observations holding every protocol line, as a live poke-env battle keeps them.
+    BattleIterator skips "|" separator lines, so we restore the full per-turn events
+    to faithfully mirror a real self-play battle's ``observations``."""
+    it = BattleIterator(bd, perspective=perspective, omniscient=True)
+    while not it.battle.finished:
+        try:
+            it.next()
+        except StopIteration:
+            break
+
+    buckets, current, turn = {}, [], 0
+    for line in bd.logs:
+        current.append(line.split("|"))
+        if line.startswith("|turn|"):
+            buckets[turn] = Observation(events=current)
+            turn += 1
+            current = []
+    buckets[turn] = Observation(events=current)
+    it.battle._observations = buckets
+    return it.battle
+
+
+@pytest.mark.parametrize("path", FILES, ids=IDS)
+def test_build_self_play_battle_data_end_to_end(path):
+    """Full path with no Showdown server: from_self_play reconstructs logs + teams
+    from two finished battles, merge_input_logs rebuilds the input log, and the
+    result equals the original battle's input log."""
+    bd = _load(path)
+    original = list(bd.input_logs)
+    p1_log, p2_log = _split(original)
+
+    p1_battle = _faithful_self_play_battle(bd, "p1")
+    p2_battle = _faithful_self_play_battle(bd, "p2")
+    new_bd = build_self_play_battle_data(p1_battle, p2_battle, p1_log, p2_log)
+
+    assert new_bd.input_logs == original


### PR DESCRIPTION
Closes #56 - serializes a self-play battle into a replayable `BattleData`.

Self-play battles don't get a server-side input log, so each player records its own orders as it makes them and we stitch the two back together:

- `InputLogRecorder` - a `Player` mixin that records each order in `input_logs` format as it's made (sync and async).
- `merge_input_logs` - interleaves the two players' inputs into one ordered log, driving the interleave off `BattleIterator`'s protocol walk so it stays correct through the awkward cases: pivot moves, Revival Blessing, and faint replacements on one or both sides.
- `build_self_play_battle_data` - glue over `BattleData.from_self_play`.

To merge cleanly it adds one small additive read to `BattleIterator` (`last_input_owners`) - no behavior change, all existing iterator tests still pass.

Tests round-trip all 23 anon fixtures three ways (merge, converter, and the full `from_self_play` -> replay end-to-end) plus the recorder; ruff/mypy/pyright clean.

It targets self-play where each decision is one well-formed order. It isn't hardened for agents that emit malformed orders (e.g. an invalid-choice re-try or a per-slot `default`) - those are caught best-effort rather than silently corrupting the log, but I wouldn't rely on it there. I also haven't run it live yet.
